### PR TITLE
fix: cap concurrent yt-dlp channel fetches to 5

### DIFF
--- a/backend/src/services/recommendation.service.ts
+++ b/backend/src/services/recommendation.service.ts
@@ -4,6 +4,7 @@ import { YouTubeSearchResult } from '../types/youtube.types';
 import historyService from './history.service';
 import youtubeService from './youtube.service';
 import logger from '../utils/logger';
+import { pLimit } from '../utils/pLimit';
 
 interface ChannelRecommendationPage {
   recommendations: ChannelRecommendation[];
@@ -16,6 +17,8 @@ interface ChannelRecommendationPage {
  */
 class RecommendationService {
   private readonly VIDEOS_PER_CHANNEL = 20; // 每個頻道推薦 20 首影片（橫向滾動 lazy load）
+  // RPi CPU/記憶體有限：每次最多 5 個 yt-dlp 子程序並行抓頻道影片，避免 spawn 30+ 進程打爆主機
+  private readonly channelFetchLimit = pLimit(5);
 
   private normalizeChannelVideos(videos: YouTubeSearchResult[]): YouTubeSearchResult[] {
     return videos
@@ -136,39 +139,39 @@ class RecommendationService {
         logger.info(`[Recommend] Overfetch history channels: cursor=${cursor}, batch=${batch.length}, collected=${collected.length}`);
 
         const recommendations = await Promise.all(
-          batch.map(async (channel) => {
+          batch.map((channel) => this.channelFetchLimit(async () => {
             logger.info(`[Recommend] Processing channel: ${channel.channelName}`);
             // 檢查 6 小時快取
             const cached = this.getCachedRecommendations(channel.channelName);
             if (cached) {
-            logger.info(`[Recommend] Cache hit for channel: ${channel.channelName}`);
-            const normalizedCached = this.normalizeChannelVideos(cached);
-            return {
-              channelName: channel.channelName,
-              channelThumbnail: channel.channelThumbnail,
-              videos: normalizedCached.slice(0, this.VIDEOS_PER_CHANNEL),
-              watchCount: channel.watchCount,
-              hasMoreVideos: normalizedCached.length > this.VIDEOS_PER_CHANNEL,
-            };
-          }
+              logger.info(`[Recommend] Cache hit for channel: ${channel.channelName}`);
+              const normalizedCached = this.normalizeChannelVideos(cached);
+              return {
+                channelName: channel.channelName,
+                channelThumbnail: channel.channelThumbnail,
+                videos: normalizedCached.slice(0, this.VIDEOS_PER_CHANNEL),
+                watchCount: channel.watchCount,
+                hasMoreVideos: normalizedCached.length > this.VIDEOS_PER_CHANNEL,
+              };
+            }
 
-          // 獲取新影片（3s timeout 防止 YouTube rate-limit 時 hang 住）
-          logger.info(`[Recommend] No cache. Fetching videos for channel: ${channel.channelName}`);
-          const videos = await Promise.race([
-            youtubeService.getChannelVideos(channel.channelName, this.VIDEOS_PER_CHANNEL + 1),
-            new Promise<YouTubeSearchResult[]>(resolve => setTimeout(() => {
-              logger.warn(`[Recommend] Timeout fetching videos for channel: ${channel.channelName}`);
-              resolve([]);
-            }, 3000)),
-          ]);
-          logger.info(`[Recommend] Fetched ${videos.length} videos for channel: ${channel.channelName}`);
+            // 獲取新影片（3s timeout 防止 YouTube rate-limit 時 hang 住）
+            logger.info(`[Recommend] No cache. Fetching videos for channel: ${channel.channelName}`);
+            const videos = await Promise.race([
+              youtubeService.getChannelVideos(channel.channelName, this.VIDEOS_PER_CHANNEL + 1),
+              new Promise<YouTubeSearchResult[]>(resolve => setTimeout(() => {
+                logger.warn(`[Recommend] Timeout fetching videos for channel: ${channel.channelName}`);
+                resolve([]);
+              }, 3000)),
+            ]);
+            logger.info(`[Recommend] Fetched ${videos.length} videos for channel: ${channel.channelName}`);
 
-          const sorted = this.normalizeChannelVideos(videos);
+            const sorted = this.normalizeChannelVideos(videos);
 
-          // 快取結果（6 小時）
-          if (sorted.length > 0) {
-            this.cacheRecommendations(channel.channelName, sorted);
-          }
+            // 快取結果（6 小時）
+            if (sorted.length > 0) {
+              this.cacheRecommendations(channel.channelName, sorted);
+            }
 
             return {
               channelName: channel.channelName,
@@ -177,7 +180,7 @@ class RecommendationService {
               watchCount: channel.watchCount,
               hasMoreVideos: sorted.length > this.VIDEOS_PER_CHANNEL,
             };
-          })
+          }))
         );
 
         const validRecommendations = recommendations.filter(r => r.videos.length > 0);

--- a/backend/src/utils/pLimit.ts
+++ b/backend/src/utils/pLimit.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal concurrency limiter (p-limit-style).
+ * 限制同時執行的非同步任務數量，避免 RPi 上一次 spawn 太多 yt-dlp 子程序打爆記憶體 / CPU。
+ */
+export type LimitFn = <T>(fn: () => Promise<T>) => Promise<T>;
+
+export function pLimit(concurrency: number): LimitFn {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error(`pLimit: concurrency must be a positive integer, got ${concurrency}`);
+  }
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const next = () => {
+    if (active >= concurrency) return;
+    const run = queue.shift();
+    if (run) run();
+  };
+
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        active++;
+        Promise.resolve()
+          .then(fn)
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            next();
+          });
+      };
+
+      if (active < concurrency) {
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- Recommendation feed used `Promise.all` over a 10+ channel batch, spawning that many `yt-dlp` subprocesses concurrently and overwhelming the RPi host.
- Added `backend/src/utils/pLimit.ts` (~30-line semaphore, no new deps).
- `RecommendationService` now wraps each channel fetch in a shared `pLimit(5)`, so over-fetching loops cannot fan out unbounded.

## Test plan
- [ ] `npm run build` (backend) — confirm no type errors
- [ ] After deploy: load home recommendations and confirm RPi process count for `yt-dlp` peaks ≤ 5
- [ ] Verify recommendations still populate (no regression in result count or latency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)