### PR TITLE
fix: stream attaches to in-progress DM download (no abort, no wait)

### DIFF
--- a/backend/src/controllers/youtube.controller.ts
+++ b/backend/src/controllers/youtube.controller.ts
@@ -156,6 +156,14 @@ export class YouTubeController {
         return;
       }
 
+      // 若 download manager 已在下載這首（例如搜尋後 precache），直接 attach 共用 yt-dlp
+      // 立即 replay 已下載的 chunks + 接收後續 chunks，避免重複 spawn 浪費 RPi 資源
+      if (downloadManager.attachStreamConsumer(videoId, req, res)) {
+        console.log(`🎵 [Stream] Attached to in-progress DM download: ${videoId}`);
+        logger.info(`Streaming audio for video: ${videoId} via DM attach`);
+        return;
+      }
+
       // Check for in-flight yt-dlp process for this videoId
       if (this.inFlightStreams.has(videoId)) {
         console.log(`⏳ [Stream] In-flight yt-dlp already running for ${videoId}, waiting for completion`);
@@ -172,36 +180,9 @@ export class YouTubeController {
         console.log(`⚠️ [Stream] In-flight completed but no cache for ${videoId}, starting new stream`);
       }
 
-      // Wait for in-progress DM download instead of spawning a competing yt-dlp
-      const dmPromise = downloadManager.awaitDownload(videoId);
-      if (dmPromise) {
-        console.log(`⏳ [Stream] DM downloading ${videoId}, waiting up to 30s`);
-        let timeoutHandle: NodeJS.Timeout | null = null;
-        try {
-          const result = await Promise.race([
-            dmPromise,
-            new Promise<null>(resolve => {
-              timeoutHandle = setTimeout(() => resolve(null), 30000);
-            }),
-          ]);
-          if (timeoutHandle) clearTimeout(timeoutHandle);
-          if (result && audioCacheService.has(videoId)) {
-            console.log(`✅ [Stream] DM completed → serving from cache: ${videoId}`);
-            this.streamFromCache(req, res, videoId);
-            return;
-          }
-        } catch {
-          if (timeoutHandle) clearTimeout(timeoutHandle);
-        }
-        console.log(`⚠️ [Stream] DM wait ended without cache for ${videoId}, falling to yt-dlp stream`);
-      }
-
       // 使用 yt-dlp 直接串流（避免 403）
       console.log(`🎵 [Stream] yt-dlp direct stream: ${videoId}`);
       logger.info(`Streaming audio for video: ${videoId} via yt-dlp direct`);
-
-      // 取消背景下載管理器中同一首歌的低優先級下載，避免兩個 yt-dlp 同時跑
-      downloadManager.abortForVideoId(videoId);
 
       // Track this stream as in-flight
       let resolveInFlight: () => void;

--- a/backend/src/services/download-manager.service.ts
+++ b/backend/src/services/download-manager.service.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, spawn } from 'child_process';
+import { Request, Response } from 'express';
 import * as fs from 'fs';
 import youtubeService from './youtube.service';
 import audioCacheService from './audio-cache.service';
@@ -8,6 +9,9 @@ import logger from '../utils/logger';
  * 雙佇列下載管理器
  * Queue 1 (HIGH): 當前播放的歌曲 — 換歌立即 abort 舊的
  * Queue 2 (LOW):  背景預快取 — high priority 啟動時暫停
+ *
+ * 同時也是 stream 來源：HTTP /stream 端點透過 attachStreamConsumer 共享
+ * 正在進行的 yt-dlp 進程 + 已下載的 chunks，避免重複 spawn 拖垮 RPi。
  */
 
 interface Job {
@@ -15,6 +19,10 @@ interface Job {
   proc: ChildProcess;
   resolve: (path: string | null) => void;
   reject: (err: Error) => void;
+  chunks: Buffer[];          // Buffered stdout for late stream consumers
+  consumers: Response[];     // Live HTTP responses receiving fanned-out chunks
+  ended: boolean;            // proc.stdout finished (success or fail)
+  succeeded: boolean | null; // null = in progress, true = cache file ready, false = failed
 }
 
 const MAX_LOW_PRIORITY = 3;
@@ -43,6 +51,36 @@ class DownloadManager {
         const oldReject = this.highPriority!.reject;
         this.highPriority!.resolve = (path) => { oldResolve(path); resolve(path); };
         this.highPriority!.reject = (err) => { oldReject(err); reject(err); };
+      });
+    }
+
+    // 同一首歌已在低優先級下載？提升為高優先級（保留進度與已 attach 的 stream consumers）
+    const lowIdx = this.lowPriority.findIndex(j => j.videoId === videoId);
+    if (lowIdx !== -1) {
+      const existing = this.lowPriority[lowIdx];
+      this.lowPriority.splice(lowIdx, 1);
+      console.log(`⬆️ [DM] Promoting low → high: ${videoId}`);
+
+      // 殺掉舊的高優先級（不同歌）
+      if (this.highPriority) {
+        console.log(`⚡ [DM] Aborting high-priority: ${this.highPriority.videoId} → ${videoId}`);
+        this.killJob(this.highPriority);
+        this.highPriority = null;
+      }
+      // 殺掉其他低優先級
+      for (const job of this.lowPriority) {
+        console.log(`⏸️ [DM] Pausing low-priority: ${job.videoId}`);
+        this.lowQueue.unshift(job.videoId);
+        this.killJob(job);
+      }
+      this.lowPriority = [];
+
+      this.highPriority = existing;
+      return new Promise((resolve, reject) => {
+        const oldResolve = existing.resolve;
+        const oldReject = existing.reject;
+        existing.resolve = (path) => { oldResolve(path); resolve(path); };
+        existing.reject = (err) => { oldReject(err); reject(err); };
       });
     }
 
@@ -100,16 +138,22 @@ class DownloadManager {
   }
 
   /**
-   * 取消正在進行或排隊的低優先級下載（供串流端點使用，避免同一首歌有兩個 yt-dlp 同時運行）
+   * 取消低優先級下載。
+   * 注意：若有 stream consumer 已 attach 到該 job，禁止 abort（會中斷使用者播放）。
    */
   abortForVideoId(videoId: string): void {
     // 從等待佇列移除
     this.lowQueue = this.lowQueue.filter(id => id !== videoId);
-    // 殺掉正在進行的低優先級 job
+    // 殺掉正在進行的低優先級 job（除非有 stream 訂閱）
     const idx = this.lowPriority.findIndex(j => j.videoId === videoId);
     if (idx !== -1) {
-      console.log(`⚡ [DM] Aborting low-priority download (stream requested): ${videoId}`);
-      this.killJob(this.lowPriority[idx]);
+      const job = this.lowPriority[idx];
+      if (job.consumers.length > 0) {
+        console.log(`🛡️ [DM] Skip abort for ${videoId}: ${job.consumers.length} stream consumer(s) attached`);
+        return;
+      }
+      console.log(`⚡ [DM] Aborting low-priority download: ${videoId}`);
+      this.killJob(job);
       this.lowPriority.splice(idx, 1);
       // 讓其他佇列中的任務繼續
       this.processLowQueue();
@@ -121,6 +165,8 @@ class DownloadManager {
    * Returns a Promise that resolves with the cached path (or null on failure).
    * Returns null immediately if the videoId is not currently downloading.
    * Callers should impose their own timeout (e.g. Promise.race with a setTimeout).
+   *
+   * (保留供其他呼叫端使用；stream 端點現已改用 attachStreamConsumer 直接 fan-out。)
    */
   awaitDownload(videoId: string): Promise<string | null> | null {
     const isActive =
@@ -153,6 +199,63 @@ class DownloadManager {
     if (this.lowPriority.some(j => j.videoId === videoId)) return { status: 'downloading-low' };
     if (this.lowQueue.includes(videoId)) return { status: 'queued' };
     return { status: 'none' };
+  }
+
+  /**
+   * 嘗試將 HTTP response attach 到正在進行的下載。
+   * 找得到 job → 共用 yt-dlp 進程 + 共用 chunks，立即 replay 已下載的部分，回傳 true。
+   * 找不到 → 回傳 false，由呼叫端自行 spawn yt-dlp。
+   */
+  attachStreamConsumer(videoId: string, req: Request, res: Response): boolean {
+    const job = this.findActiveJob(videoId);
+    if (!job) return false;
+
+    // 任務已失敗結束 → 不能 serve 半成品
+    if (job.ended && job.succeeded === false) return false;
+
+    console.log(`🔗 [DM] Attaching stream consumer for ${videoId} (buffered=${job.chunks.length} chunks, ended=${job.ended})`);
+
+    if (!res.headersSent) {
+      res.status(200);
+      res.setHeader('Content-Type', 'audio/mp4');
+      res.setHeader('Transfer-Encoding', 'chunked');
+      res.setHeader('Accept-Ranges', 'bytes');
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges');
+      res.setHeader('Cache-Control', 'no-cache');
+    }
+
+    // Replay 已經下載到的 chunks
+    for (const chunk of job.chunks) {
+      if (res.writableEnded) return true;
+      try { res.write(chunk); } catch { return true; }
+    }
+
+    // proc 已成功結束 → 直接 end
+    if (job.ended) {
+      if (!res.writableEnded) {
+        try { res.end(); } catch {}
+      }
+      return true;
+    }
+
+    // 加入 live consumer 列表
+    job.consumers.push(res);
+
+    const cleanup = () => {
+      const idx = job.consumers.indexOf(res);
+      if (idx !== -1) job.consumers.splice(idx, 1);
+    };
+    req.once('close', cleanup);
+    res.once('close', cleanup);
+    res.once('finish', cleanup);
+
+    return true;
+  }
+
+  private findActiveJob(videoId: string): Job | null {
+    if (this.highPriority?.videoId === videoId) return this.highPriority;
+    return this.lowPriority.find(j => j.videoId === videoId) || null;
   }
 
   private processLowQueue(): void {
@@ -204,9 +307,38 @@ class DownloadManager {
       this.triggerCompletionCallbacks(videoId, path);
     };
 
+    const job: Job = {
+      videoId,
+      proc,
+      resolve: callResolve, // stored so killJob can fire it (and thus callbacks)
+      reject,
+      chunks: [],
+      consumers: [],
+      ended: false,
+      succeeded: null,
+    };
+
+    const endConsumers = () => {
+      for (const res of job.consumers) {
+        if (!res.writableEnded) {
+          try { res.end(); } catch {}
+        }
+      }
+      job.consumers.length = 0;
+    };
+
     proc.stdout.on('data', (chunk: Buffer) => {
       if (aborted) return;
       downloadedBytes += chunk.length;
+      job.chunks.push(chunk);
+
+      // Fan out to live stream consumers
+      for (const res of job.consumers) {
+        if (!res.writableEnded) {
+          try { res.write(chunk); } catch {}
+        }
+      }
+
       const ok = writeStream.write(chunk);
       if (!ok) {
         proc.stdout.pause();
@@ -227,6 +359,10 @@ class DownloadManager {
               fs.renameSync(tempPath, cachePath);
               audioCacheService.remuxIfNeeded(cachePath);
               console.log(`✅ [DM] Downloaded: ${videoId} (${(stats.size / 1024 / 1024).toFixed(2)} MB)`);
+              job.succeeded = true;
+              job.ended = true;
+              endConsumers();
+              job.chunks.length = 0; // free memory
               callResolve(cachePath);
               return;
             }
@@ -235,6 +371,10 @@ class DownloadManager {
           }
         }
         try { fs.unlinkSync(tempPath); } catch {}
+        job.succeeded = false;
+        job.ended = true;
+        endConsumers();
+        job.chunks.length = 0;
         callResolve(null);
       });
     });
@@ -243,6 +383,10 @@ class DownloadManager {
       if (aborted) return;
       console.error(`❌ [DM] Process error: ${videoId}`, err);
       try { fs.unlinkSync(tempPath); } catch {}
+      job.succeeded = false;
+      job.ended = true;
+      endConsumers();
+      job.chunks.length = 0;
       callResolve(null);
     });
 
@@ -252,13 +396,6 @@ class DownloadManager {
         // Only log non-warning stderr
       }
     });
-
-    const job: Job = {
-      videoId,
-      proc,
-      resolve: callResolve, // stored so killJob can fire it (and thus callbacks)
-      reject,
-    };
 
     return job;
   }
@@ -270,6 +407,16 @@ class DownloadManager {
         try { job.proc.kill('SIGKILL'); } catch {}
       }, 2000);
     } catch {}
+    // End any attached stream consumers (truncated audio is better than hanging forever)
+    for (const res of job.consumers) {
+      if (!res.writableEnded) {
+        try { res.end(); } catch {}
+      }
+    }
+    job.consumers.length = 0;
+    job.chunks.length = 0;
+    job.ended = true;
+    job.succeeded = false;
     job.resolve(null); // Resolve with null, don't reject (cleaner)
     // Clean up temp file
     const tempPath = audioCacheService.getCachePath(job.videoId) + '.tmp';


### PR DESCRIPTION
## Summary
- When `/api/stream/:videoId` is hit while the download manager is already fetching that videoId (e.g. via search precache), the stream now fans out the live yt-dlp stdout to the HTTP response instead of awaiting completion or aborting+respawning.
- Replays buffered chunks instantly to the client and forwards future chunks as they arrive — eliminates dead-air wait that timed out frontends on RPi.
- DM `playNow()` now promotes a same-videoId low-priority job to high priority instead of killing+respawning yt-dlp from zero.
- DM `abortForVideoId()` refuses to kill a job that has stream consumers attached.

## Root cause
On RPi, search precache spawns a low-priority yt-dlp. When the user clicks a precached track, the old `/stream` route called `downloadManager.abortForVideoId(videoId)` to kill the in-progress download, then spawned its own yt-dlp from zero. RPi was too slow to deliver the first byte before the browser timed out.

The previous fix (commit d0f3e18) replaced the abort with a 30s `awaitDownload` race + fall-through to a new yt-dlp spawn — which still produced 30 seconds of dead-air for the client (browser timeout) and then a duplicate spawn anyway.

This change removes both wait and respawn: the stream borrows the existing yt-dlp's stdout via an in-memory chunk buffer + live consumer list. Cache write proceeds normally; the consumer just receives a copy of the same bytes.

## Test plan
- [ ] Search a song → click before precache finishes → audio plays without 30s gap.
- [ ] Cache hit path still serves from disk (unchanged).
- [ ] Multiple devices hitting the same uncached videoId share one yt-dlp process.
- [ ] No regression for tracks where stream arrives before precache (falls through to direct yt-dlp spawn as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)